### PR TITLE
drivers: ethernet: dsa_ksz8xxx: use NET_DEVICE_DT_DEFINE_INSTANCE

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -1064,8 +1064,7 @@ static struct dsa_api dsa_api_f = {
 	const struct dsa_slave_config dsa_0_slave_##slave##_config = {     \
 		.mac_addr = DT_PROP_OR(slave, local_mac_address, {0})      \
 	};                                                                 \
-	NET_DEVICE_INIT_INSTANCE(dsa_slave_port_##slave,                   \
-	DT_LABEL(slave),                                                   \
+	NET_DEVICE_DT_DEFINE_INSTANCE(slave,                               \
 	n,                                                                 \
 	dsa_port_init,                                                     \
 	NULL,                                                              \


### PR DESCRIPTION
Move to using NET_DEVICE_DT_DEFINE_INSTANCE instead of
NET_DEVICE_INIT_INSTANCE as the driver is devicetree based and it
lets us remove DT_LABEL usage in the driver itself.

Signed-off-by: Kumar Gala <galak@kernel.org>